### PR TITLE
Remplace hard coded table name by config

### DIFF
--- a/src/Models/Promocode.php
+++ b/src/Models/Promocode.php
@@ -133,7 +133,7 @@ class Promocode extends Model implements PromocodeContract
      */
     public function appliedByUser(Model $user): bool
     {
-        return $this->users()->where(DB::raw('users.id'), $user->id)->exists();
+        return $this->users()->where(DB::raw(config('promocodes.models.users.table_name') . '.id'), $user->id)->exists();
     }
 
     /**


### PR DESCRIPTION
if we use a "users" model (add table_name) different from `\App\Models\User::class' the `appliedByUser()` method failed with an SQL error: 

```
Illuminate\Database\QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column &#039;users.id&#039; in &#039;where clause&#039; (SQL: select exists(select * from `competitors` inner join `promocode_competitor` on `competitors`.`id` = `promocode_competitor`.`user_id` where `promocode_competitor`.`promocode_id` = 1 and users.id = 6 and `competitors`.`deleted_at` is null) as `exists`) 
```