### PR TITLE
fix decrementing usages_left when promo is unlimited

### DIFF
--- a/src/Promocodes.php
+++ b/src/Promocodes.php
@@ -251,7 +251,9 @@ class Promocodes
             event(new GuestAppliedPromocode($this->promocode));
         }
 
-        $this->promocode->decrement('usages_left');
+        if (!$this->promocode->isUnlimited()) {
+            $this->promocode->decrement('usages_left');
+        }
 
         return $this->promocode;
     }


### PR DESCRIPTION
Hi @zgabievi I hope you are fine
I fixed an issue with the usages_left  decrement if the code was unlimited
by adding condition  decrement only when the code is a limited use 